### PR TITLE
minor fixes in MLP backprop

### DIFF
--- a/static/code/backpropagation/mlp.py
+++ b/static/code/backpropagation/mlp.py
@@ -18,7 +18,7 @@ class MLP:
 
     def fit(self, inputs, targets, train=True):
         outputs = self.forward(inputs)
-        probs = softmax(outputs[-1])
+        probs = outputs[-1]
         if train:
             self.backward(inputs, targets, *outputs)
 

--- a/static/code/backpropagation/mlp.py
+++ b/static/code/backpropagation/mlp.py
@@ -35,7 +35,7 @@ class MLP:
         grad_h = torch.mm(grad_logits, self.w_output.T)
         grad_htilde = grad_h * grad_tanh(h)
         grad_wh = torch.mm(inputs.T, grad_htilde) / batch_size
-        grad_bh = torch.sum(grad_h, dim=0) / batch_size
+        grad_bh = torch.sum(grad_htilde, dim=0) / batch_size
 
         self.w_output = self.w_output - self.learning_rate * grad_wo
         self.b_output = self.b_output - self.learning_rate * grad_bo


### PR DESCRIPTION
Hi Arthur, nice work on Deep Course! I was going through it to have a refresher on CV and noticed some potential errors on mlp.py:
1.  the softmax in self.fit is redundant since it was already performed in self.forward to produce the probs
2. grad_bh depends on grad_htilde, not grad_h, since tanh is performed on XW+b